### PR TITLE
Fix tokenizer download by using `token` instead of `auth_token`

### DIFF
--- a/intermodel/hf_token.py
+++ b/intermodel/hf_token.py
@@ -13,7 +13,7 @@ def get_hf_tokenizer(hf_name) -> "Tokenizer":
         from tokenizers import Tokenizer
 
         hf_tokenizers[hf_name] = Tokenizer.from_pretrained(
-            hf_name, auth_token=get_hf_auth_token()
+            hf_name, token=get_hf_auth_token()
         )  # log in with "huggingface-cli login"
         return hf_tokenizers[hf_name]
 


### PR DESCRIPTION
The HuggingFace `tokenizers` library's `Tokenizer.from_pretrained` method deprecated and removed the `auth_token` argument in favor of `token`. This commit updates the argument in `intermodel/hf_token.py` to fix the tokenizer download failure.

---
*PR created automatically by Jules for task [16640271053249677480](https://jules.google.com/task/16640271053249677480) started by @ampdot-io*